### PR TITLE
fixes typos, fixes api for xbox live users

### DIFF
--- a/lib/overwatch_parser.rb
+++ b/lib/overwatch_parser.rb
@@ -6,6 +6,9 @@ class OverwatchParser
     battletag.gsub!('#','-') #TODO: F0002: Smarter, when # is in the nickname
     url = 'https://playoverwatch.com/en-us/career'
     profile_page = [url, platform, region, battletag].join('/')
+    unless platform != 'xbl'
+      profile_page = [url, platform, battletag].join('/')
+    end
     puts "Opening: #{profile_page}"
     @nokogiri_page = Nokogiri::HTML(open(profile_page))
   end
@@ -62,7 +65,7 @@ class OverwatchParser
         #todo: consider if done  # Cannot do it yet. Needs JS to parse after....
         results[key] << {
           xx.css('.content').text => {
-            achived: !x.css('.media-card').last.attributes.to_s.include?('m-disabled'),
+            achieved: !x.css('.media-card').last.attributes.to_s.include?('m-disabled'),
             img: x.css('img').last['src']
           }
         }
@@ -106,7 +109,7 @@ class ParsedPaclulator
     }
   end
   def self.everything(owp)
-    modes = ['quick-play', 'competative-play']
+    modes = ['quick-play', 'competetive-play']
     result = {
       nickname: owp.nickname,
       level: owp.level,

--- a/lib/overwatch_parser.rb
+++ b/lib/overwatch_parser.rb
@@ -6,7 +6,7 @@ class OverwatchParser
     battletag.gsub!('#','-') #TODO: F0002: Smarter, when # is in the nickname
     url = 'https://playoverwatch.com/en-us/career'
     profile_page = [url, platform, region, battletag].join('/')
-    unless region == 'xbl'
+    unless platform != 'xbl'
       profile_page = [url, platform, battletag].join('/')
     end
     puts "Opening: #{profile_page}"


### PR DESCRIPTION
The url scheme is different for PC/PSN users and XBL users.

XBL: https://playoverwatch.com/en-us/career/pc/<xboxlivename>
PC/PSN: https://playoverwatch.com/en-us/career/pc/us/battletagname-xxxx

This commit adds a check for XBL users.

